### PR TITLE
排除p6.c的异常

### DIFF
--- a/Chapter-04/p6.c
+++ b/Chapter-04/p6.c
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
             }
         }
         if (l != cnt) {  // 将没有复制过去的所有都复制过去
-            if (write(fd2, buff + l, cnt - l)) {
+            if (write(fd2, buff + l, cnt - l) == -1) {
                 printf("fd2 write failure\n");
                 exit(1);
             }


### PR DESCRIPTION
自己在deepin15.11上操作总是报错fd2 write failure,然后测试排查发现write返回写入字节数,这样就会报错,所以加上` == -1`
write函数的返回值情况(https://linux.die.net/man/2/write): 
On success, **the number of bytes written is returned (zero indicates nothing was written)**. On error, -1 is returned, and errno is set appropriately.

请求合并,谢谢