### PR TITLE
Improve the use of fcntl function in p3.c

### DIFF
--- a/Chapter-03/p3.c
+++ b/Chapter-03/p3.c
@@ -3,20 +3,51 @@
 #include <fcntl.h>
 
 int main() {
+    printf("-------------------------------------------------\n");
     int fd1 = open("test.txt", O_RDONLY);
     int fd2 = dup(fd1);
     int fd3 = open("test.txt", O_RDONLY);
 
-    printf("fd1 = %d\n", fcntl(fd1, F_GETFD));
-    fcntl(fd1, F_SETFD, 1);
-    printf("fd1 = %d\n", fcntl(fd1, F_GETFD));
+    printf("fd1 = %d\n", fd1);
+    printf("fd2 = %d\n", fd2);
+    printf("fd3 = %d\n", fd3);
+    printf("-------------------------------------------------\n");
 
-    printf("fd2 = %d\n", fcntl(fd2, F_GETFD));
-    fcntl(fd1, F_SETFD, 0);
+    int fd1_flags = fcntl(fd1, F_GETFD);
+    int fd2_flags = fcntl(fd2, F_GETFD);
+    int fd3_flags = fcntl(fd3, F_GETFD);
 
-    fcntl(fd1, F_SETFL, 3);
-    printf("fd1 = %d\n", fcntl(fd1, F_GETFL));
-    printf("fd2 = %d\n", fcntl(fd2, F_GETFL));
-    printf("fd3 = %d\n", fcntl(fd3, F_GETFL));
+    printf("Before fcntl(fd1, F_SETFD, fd1_flags):\n");
+    printf("fd1_flags = %d\n", fd1_flags);
+    printf("fd2_flags = %d\n", fd2_flags);
+    printf("fd3_flags = %d\n", fd3_flags);
+    printf("-------------------------------------------------\n");
+
+    // 设置 FD_CLOEXEC 标志（其他标志不变）
+    fd1_flags |= FD_CLOEXEC;
+    fcntl(fd1, F_SETFD, fd1_flags);
+
+    printf("After fcntl(fd1, F_SETFD, fd1_flags):\n");
+    printf("fd1_flags = %d\n", fd1_flags);
+    printf("fd2_flags = %d\n", fd2_flags);
+    printf("fd3_flags = %d\n", fd3_flags);
+    printf("-------------------------------------------------\n");
+
+    printf("Before fcntl(fd1, F_SETFL, fd1_file_status_flags):\n");
+    printf("fd1_file_status_flags = %d\n", fcntl(fd1, F_GETFL, 0));
+    printf("fd2_file_status_flags = %d\n", fcntl(fd2, F_GETFL, 0));
+    printf("fd3_file_status_flags = %d\n", fcntl(fd3, F_GETFL, 0));
+    printf("-------------------------------------------------\n");
+
+    int fd1_file_status_flag = fcntl(fd1, F_GETFL, 0);
+    fd1_file_status_flag |= O_APPEND;
+    fcntl(fd1, F_SETFL, fd1_file_status_flag);
+
+    printf("After fcntl(fd1, F_SETFL, fd1_file_status_flags):\n");
+    printf("fd1_file_status_flags = %d\n", fcntl(fd1, F_GETFL, 0));
+    printf("fd2_file_status_flags = %d\n", fcntl(fd2, F_GETFL, 0));
+    printf("fd3_file_status_flags = %d\n", fcntl(fd3, F_GETFL, 0));
+    printf("-------------------------------------------------\n");
+
     return 0;
 }


### PR DESCRIPTION
书中示例部分原文：
When we modify either the file descriptor flags or the file status flags, we must be careful to fetch the existing flag value, modify it as desired, and then set the new flag value. We can’t simply issue an F_SETFD or an F_SETFL command, as this could turn off flag bits that were previously set. 

我在Ubuntu24下运行原来的代码是存在问题的，fcntl(fd1, F_SETFL, 3)并没有修改fd1和fd2的文件状态标志，文件状态标志3无效。

O_RDONLY=0，O_WRONLY=1，O_RDWR=2（这些是访问模式，F_SETFL 无法修改）。
3 相当于 O_WRONLY | O_RDWR，这是矛盾的（不可能同时是只写和读写），且属于不可修改的访问模式，因此 fcntl 会忽略该设置，导致状态不变。

此外，原来代码printf的意图有些不太明朗。